### PR TITLE
Use Enumerator#reject instead of array iteration for selecting bad headers

### DIFF
--- a/lib/modsulator.rb
+++ b/lib/modsulator.rb
@@ -128,16 +128,8 @@ class Modsulator
   # @return [Array<String>]                    A list of spreadsheet headers that did not appear in the XML template. This list
   #                                            will be empty if all the headers were present.
   def validate_headers(spreadsheet_headers, template_xml)
-    missing_headers = Array.new
-
-    spreadsheet_headers.each do |header|
-      if((header != nil) &&
-         !(header == "sourceId") &&
-         !(template_xml.include? header))
-        missing_headers.push(header)
-      end
+    spreadsheet_headers.reject do |header|
+      header.nil? || header == "sourceId" || template_xml.include?(header)
     end
-
-    return missing_headers
   end
 end

--- a/spec/lib/modsulator_spec.rb
+++ b/spec/lib/modsulator_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+describe Modsulator do
+  describe "#validate_headers" do
+    let(:template_xml) { "abc def ghi"}
+    it "should include headers not in the template string" do
+      expect(subject.validate_headers(["abc", "phi"], template_xml)).not_to include "abc"
+      expect(subject.validate_headers(["abc", "phi"], template_xml)).to include "phi"
+    end
+  end
+end


### PR DESCRIPTION
Here's a suggestion for improving the `#validate_headers` method by using `Enumerable` methods instead of building up an array by iteration.
