### PR TITLE
Add spreadsheet_template_path

### DIFF
--- a/lib/modsulator.rb
+++ b/lib/modsulator.rb
@@ -8,11 +8,14 @@ require 'nokogiri'
 require 'roo'
 require 'stanford/mods/normalizer'
 require 'modsulator/modsulator_sheet'
-
+require 'deprecation'
 
 # The main class for the MODSulator API, which lets you work with metadata spreadsheets and MODS XML.
 # @see https://consul.stanford.edu/display/chimera/MODS+bulk+loading Requirements (Stanford Consul page)
 class Modsulator
+  extend Deprecation
+  self.deprecation_horizon = 'modsulator version 2.0.0'
+
   # We define our own namespace for <xmlDocs>
   NAMESPACE = 'http://library.stanford.edu/xmlDocs'
 
@@ -180,10 +183,22 @@ class Modsulator
   end
 
 
-  # Returns the template spreadsheet that's built into this gem.
-  #
-  # @return      The template spreadsheet, in binary form.
-  def self.get_template_spreadsheet
-    IO.read(File.expand_path('../modsulator/modsulator_template.xlsx', __FILE__), mode: 'rb')
+  class << self
+    # Returns the template spreadsheet that's built into this gem.
+    #
+    # @return [String] The template spreadsheet, in binary form.
+    def get_template_spreadsheet
+      IO.read(File.expand_path('../modsulator/modsulator_template.xlsx', __FILE__), mode: 'rb')
+    end
+    deprecation_deprecate :get_template_spreadsheet
+
+    # This can be used by modsulator-rails-app so we can do:
+    #   send_file Modsulator.template_spreadsheet_path
+    # which is more memory efficient than:
+    #   render body: Modsulator.get_template_spreadsheet
+    # @return [String] the path to the spreadsheet template.
+    def template_spreadsheet_path
+      File.expand_path('../modsulator/modsulator_template.xlsx', __FILE__)
+    end
   end
 end

--- a/modsulator.gemspec
+++ b/modsulator.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'nokogiri'
   s.add_dependency 'activesupport'
   s.add_dependency 'stanford-mods-normalizer', '~> 0.1'
+  s.add_dependency 'deprecation', '~> 0'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '>= 3.0'

--- a/spec/lib/modsulator_spec.rb
+++ b/spec/lib/modsulator_spec.rb
@@ -2,17 +2,25 @@ RSpec.describe Modsulator do
   describe "#validate_headers" do
     subject { Modsulator.new File.join(FIXTURES_DIR, 'test_002.csv'), 'test_002.csv', template_string: "abc def ghi"}
     let(:template_xml) { "abc def ghi"}
-    it "should include headers not in the template string" do
+    it "includes headers not in the template string" do
       expect(subject.validate_headers(["abc", "phi"])).not_to include "abc"
       expect(subject.validate_headers(["abc", "phi"])).to include "phi"
     end
   end
 
   describe "#get_template_spreadsheet" do
-    it "should return the correct spreadsheet" do
-      downloaded_binary_string = Modsulator.get_template_spreadsheet
+    subject { Modsulator.get_template_spreadsheet }
+    it "returns the correct spreadsheet" do
       expected_binary_string = IO.read(File.join(File.expand_path("../../../lib/modsulator/", __FILE__), "modsulator_template.xlsx"), mode: 'rb')
-      expect(downloaded_binary_string).to eq(expected_binary_string)
+      expect(Deprecation).to receive(:warn)
+      expect(subject).to eq(expected_binary_string)
+    end
+  end
+
+  describe "#template_spreadsheet_path" do
+    subject { Modsulator.template_spreadsheet_path }
+    it "returns the path to the spreadsheet" do
+      expect(subject).to eq(File.join(File.expand_path("../../../lib/modsulator/", __FILE__), "modsulator_template.xlsx"))
     end
   end
 end


### PR DESCRIPTION
Deprecate get_template_spreadsheet as it's not memory efficent.
We should use `send_file Modsulator.spreadsheet_template_path` in
modsulator-app-rails